### PR TITLE
Let the OS assign a random socket port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 experiment. do not use
+
+
+## Setup
+
+The project requires the installation of the [TShark] CLI & [delv].
+
+[TShark]: https://tshark.dev/
+[delv]: https://bind9.readthedocs.io/en/latest/manpages.html#std-iscman-delv


### PR DESCRIPTION
This defers the assignment of a random UDP port to the OS to avoid any possible conflicts with existing ports.